### PR TITLE
Create non-root jira user and reference UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ ENV APP_VERSION   3.13.1
 # directory structure.
 RUN set -x \
     && apk add --no-cache curl xmlstarlet bash ttf-dejavu libc6-compat \
+    && addgroup -S jira \
+    && adduser -S -g jira -u 1000 jira \
     && mkdir -p                "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_HOME}/caches/indexes" \
     && chmod -R 700            "${JIRA_HOME}" \
-    && chown -R daemon:daemon  "${JIRA_HOME}" \
+    && chown -R jira:jira      "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_INSTALL}/conf/Catalina" \
     && curl -Ls                "https://www.atlassian.com/software/jira/downloads/binary/atlassian-servicedesk-3.13.1.tar.gz" | tar -xz --directory "${JIRA_INSTALL}" --strip-components=1 --no-same-owner \
     && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz" | tar -xz --directory "${JIRA_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar" \
@@ -22,18 +24,16 @@ RUN set -x \
     && chmod -R 700            "${JIRA_INSTALL}/logs" \
     && chmod -R 700            "${JIRA_INSTALL}/temp" \
     && chmod -R 700            "${JIRA_INSTALL}/work" \
-    && chown -R daemon:daemon  "${JIRA_INSTALL}/conf" \
-    && chown -R daemon:daemon  "${JIRA_INSTALL}/logs" \
-    && chown -R daemon:daemon  "${JIRA_INSTALL}/temp" \
-    && chown -R daemon:daemon  "${JIRA_INSTALL}/work" \
+    && chown -R jira:jira      "${JIRA_INSTALL}/conf" \
+    && chown -R jira:jira      "${JIRA_INSTALL}/logs" \
+    && chown -R jira:jira      "${JIRA_INSTALL}/temp" \
+    && chown -R jira:jira      "${JIRA_INSTALL}/work" \
     && sed --in-place          "s/java version/openjdk version/g" "${JIRA_INSTALL}/bin/check-java.sh" \
     && echo -e                 "\njira.home=$JIRA_HOME" >> "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/jira-application.properties" \
     && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml"
 
-# Use the default unprivileged account. This could be considered bad practice
-# on systems where multiple processes end up being executed by 'daemon' but
-# here we only ever run one process anyway.
-USER daemon:daemon
+# Reference the UID for the jira user.
+USER 1000
 
 # Expose default HTTP connector port.
 EXPOSE 8080


### PR DESCRIPTION
When running this image in a Kubernetes Cluster and specifying `runAsNonRoot` in your security context, the pod is rejected as it does not specify a non-numeric USER in the spec (can't determine that the user is not root). Related PR: https://github.com/kubernetes/kubernetes/pull/56503
You can set `runAsUser` to a UID in your deployment spec to bypass this, but I thought it better to solve within the Dockerfile so other users won't run into this problem.

The `USER` could be changed to reference `2` (the UID for daemon user), but I thought this was a good point to create a specific user for the app (jira, UID 1000).