### PR TITLE
Build and update image on push to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,11 @@ workflows:
   commit:
     jobs:
       - test-building-container
+      - build-and-update:
+          filters:
+            branches:
+              only:
+                - master
 
   nightly:
     triggers:


### PR DESCRIPTION
*Description of changes:*

Following the re-write of the circleci workflow, new version releases are no longer being tagged in the Docker Hub on a commit to the master branch. This PR includes an update to run the build process on a push to the master branch, which brings it more in-line with the previous workflow that was in place when this was working successfully.