### PR TITLE
Update mysql connector to 5.1.48

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
     && chown -R jira:jira      "${JIRA_HOME}" \
     && mkdir -p                "${JIRA_INSTALL}/conf/Catalina" \
     && curl -Ls                "https://www.atlassian.com/software/jira/downloads/binary/atlassian-servicedesk-4.5.1.tar.gz" | tar -xz --directory "${JIRA_INSTALL}" --strip-components=1 --no-same-owner \
-    && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz" | tar -xz --directory "${JIRA_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar" \
+    && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.48.tar.gz" | tar -xz --directory "${JIRA_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar" \
     && rm -f                   "${JIRA_INSTALL}/lib/postgresql-9.1-903.jdbc4-atlassian-hosted.jar" \
     && curl -Ls                "https://jdbc.postgresql.org/download/postgresql-9.4.5.12.jar" -o "${JIRA_INSTALL}/lib/postgresql-9.4.5.12.jar" \
     && chmod -R 700            "${JIRA_INSTALL}/conf" \


### PR DESCRIPTION
The current 5.1.38 does not support utf8mb4 properly (per https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-charsets.html), so use the latest version which, in conjunction with <database-type>mysql57</database-type> in dbconfig.xml does.


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
